### PR TITLE
Replace Sodium with CryptoSwift

### DIFF
--- a/swift/ACKNOWLEDGEMENTS.md
+++ b/swift/ACKNOWLEDGEMENTS.md
@@ -1,0 +1,7 @@
+# Acknowledgements
+
+- [Nostr SDK for Apple Platforms](https://github.com/nostr-sdk/nostr-sdk-ios) - [MIT License](https://github.com/nostr-sdk/nostr-sdk-ios/blob/main/LICENSE)
+- [secp256k1.swift](https://github.com/GigaBitcoin/secp256k1.swift) - [MIT License, Copyright (c) 2020 GigaBitcoin LLC](https://github.com/GigaBitcoin/secp256k1.swift/blob/main/LICENSE)
+- [CryptoSwift](https://github.com/krzyzanowskim/CryptoSwift) - [Copyright (C) 2014-3099 Marcin Krzyżanowski](https://github.com/krzyzanowskim/CryptoSwift/blob/main/LICENSE)
+- [Bech32](https://github.com/0xDEADP00L/Bech32/blob/master/Sources/Bech32.swift) - [MIT License, Copyright 2018 Evolution Group Limited](https://github.com/0xDEADP00L/Bech32/blob/master/LICENSE)
+- [Nos Data+Encoding.swift](https://github.com/planetary-social/nos/blob/main/Nos/Extensions/Data%2BEncoding.swift) - [MIT License, Copyright 2024 © Verse Communications](https://njump.me/note1q39598qkdc093sdq4enudjf0dall76s7n779k07nutgd9r2zt6vq96l8c2)

--- a/swift/Package.resolved
+++ b/swift/Package.resolved
@@ -1,6 +1,15 @@
 {
-  "originHash" : "1d6f7527d10cfa876d441f35200704f4b268cb92840635512b69dedb115eca19",
+  "originHash" : "92339f8ec5951d3b8a6041bec639fb77beaadfb85e55a0f7919c750587c13930",
   "pins" : [
+    {
+      "identity" : "cryptoswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/krzyzanowskim/CryptoSwift.git",
+      "state" : {
+        "revision" : "7892a123f7e8d0fe62f9f03728b17bbd4f94df5c",
+        "version" : "1.8.1"
+      }
+    },
     {
       "identity" : "secp256k1.swift",
       "kind" : "remoteSourceControl",
@@ -8,14 +17,6 @@
       "state" : {
         "revision" : "347b84ed2aad2305a7233f2a48d76f41e52062a1",
         "version" : "0.16.0"
-      }
-    },
-    {
-      "identity" : "swift-sodium",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/jedisct1/swift-sodium.git",
-      "state" : {
-        "revision" : "63240810df971557fe9badc557257bdfbfeb90a3"
       }
     }
   ],

--- a/swift/Package.swift
+++ b/swift/Package.swift
@@ -21,8 +21,8 @@ let package = Package(
             from: "0.12.2"
         ),
         .package(
-            url: "https://github.com/jedisct1/swift-sodium.git",
-            revision: "63240810df971557fe9badc557257bdfbfeb90a3"
+            url: "https://github.com/krzyzanowskim/CryptoSwift.git",
+            .upToNextMajor(from: "1.8.1")
         )
     ],
     targets: [
@@ -32,7 +32,7 @@ let package = Package(
             name: "NIP44",
             dependencies: [
                 .product(name: "secp256k1", package: "secp256k1.swift"),
-                .product(name: "Clibsodium", package: "swift-sodium")
+                "CryptoSwift"
             ]
         ),
         .testTarget(


### PR DESCRIPTION
Follows the changes made in Nostr SDK for Apple Platforms: https://github.com/nostr-sdk/nostr-sdk-ios/pull/140

I replaced the underlying cryptography library because it was causing problems for Nostr SDK for Apple Platforms in the documentation generation build step. Effectively, it's a replacement of a C library with a pure Swift library.

Acknowledgements and licenses of dependencies have also been added.