### PR TITLE
Go: Make sure private key is on curve before using unsafe secp256k1.PrivKeyFromBytes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Audited on [2023.12](./audit-2023.12.pdf) by Cure53, Dr M. Heiderich, Dr. Mazahe
 | Language        | License       | Copied from                                |
 |-----------------|---------------|--------------------------------------------|
 | F#              | GPL 2         | https://github.com/lontivero/Nostra        |
-| Go              | MIT           | https://git.ekzyis.com/ekzyis/nip44        |
+| Go              | MIT           | https://github.com/ekzyis/nip44            |
 | Kotlin          | MIT           | https://github.com/vitorpamplona/amethyst  |
 | Rust            | MIT           | https://github.com/mikedilger/nip44        |
 | Swift           | MIT           | https://github.com/nostr-sdk/nostr-sdk-ios |

--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@ NIP44 encrypted messages for [nostr](https://nostr.com).
 Spec copied from [github.com/nostr-protocol/nips](https://github.com/nostr-protocol/nips/blob/master/44.md).
 Audited on [2023.12](./audit-2023.12.pdf) by Cure53, Dr M. Heiderich, Dr. Mazaheri, Dr. Bleichenbacher.
 
-| Language        | License       | Copied from                                | Note   |
-|-----------------|---------------|--------------------------------------------|--------|
-| F#              | GPL 2         | https://github.com/lontivero/Nostra        |        |
-| Go              | MIT           | https://git.ekzyis.com/ekzyis/nip44        | Unsafe |
-| Kotlin          | MIT           | https://github.com/vitorpamplona/amethyst  |        |
-| Rust            | MIT           | https://github.com/mikedilger/nip44        |        |
-| Swift           | MIT           | https://github.com/nostr-sdk/nostr-sdk-ios |        |
-| TypeScript / JS | Public domain | https://github.com/nostr-protocol/nips     |        |
+| Language        | License       | Copied from                                |
+|-----------------|---------------|--------------------------------------------|
+| F#              | GPL 2         | https://github.com/lontivero/Nostra        |
+| Go              | MIT           | https://git.ekzyis.com/ekzyis/nip44        |
+| Kotlin          | MIT           | https://github.com/vitorpamplona/amethyst  |
+| Rust            | MIT           | https://github.com/mikedilger/nip44        |
+| Swift           | MIT           | https://github.com/nostr-sdk/nostr-sdk-ios |
+| TypeScript / JS | Public domain | https://github.com/nostr-protocol/nips     |
 
 ---
 NIP-44

--- a/go/README.md
+++ b/go/README.md
@@ -1,31 +1,5 @@
 **NIP-44 implementation in Go**
 
----
-
-**DISCLAIMER - READ BEFORE USING**
-
-**This library does not make sure yet that the secp256k1 keys you want to use for the conversation key are valid, protected against twist attacks and not contain any other weaknesses as mentioned in the [NIP-44 security audit](https://cure53.de/audit-report_nip44-implementations.pdf).**
-
-**If you really want to use this library before this is fixed, you need to make sure that the keys you use with `GenerateConversationKey` are not affected yourself.**
-
-See [documentation of `secp256k1.PrivKeyFromBytes`](https://pkg.go.dev/github.com/decred/dcrd/dcrec/secp256k1/v4#PrivKeyFromBytes) and comment in `nip44.GenerateConversationkey`:
-
-```
-func GenerateConversationKey(sendPrivkey *secp256k1.PrivateKey, recvPubkey *secp256k1.PublicKey) []byte {
-    // TODO: Make sure keys are not invalid or weak since the secp256k1 package does not.
-    // See documentation of secp256k1.PrivKeyFromBytes:
-    // ================================================================================
-    // | WARNING: This means passing a slice with more than 32 bytes is truncated and |
-    // | that truncated value is reduced modulo N.  Further, 0 is not a valid private |
-    // | key.  It is up to the caller to provide a value in the appropriate range of  |
-    // | [1, N-1].  Failure to do so will either result in an invalid private key or  |
-    // | potentially weak private keys that have bias that could be exploited.        |
-    // ================================================================================
-    // -- https://pkg.go.dev/github.com/decred/dcrd/dcrec/secp256k1/v4#PrivKeyFromBytes
-```
-
----
-
 NIP-44 specification: https://github.com/nostr-protocol/nips/blob/master/44.md
 
 To use as library: `go get -u git.ekzyis.com/ekzyis/nip44`

--- a/go/README.md
+++ b/go/README.md
@@ -2,7 +2,6 @@
 
 NIP-44 specification: https://github.com/nostr-protocol/nips/blob/master/44.md
 
-To use as library: `go get -u git.ekzyis.com/ekzyis/nip44`
+To use as library: `go get -u github.com/ekzyis/nip44`
 
 To run tests, clone repository and then run `go test`.
-

--- a/go/nip44.go
+++ b/go/nip44.go
@@ -7,10 +7,12 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/binary"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
 	"math"
+	"math/big"
 
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 	"golang.org/x/crypto/chacha20"
@@ -134,19 +136,25 @@ func Decrypt(conversationKey []byte, ciphertext string) (string, error) {
 	return string(unpadded), nil
 }
 
-func GenerateConversationKey(sendPrivkey *secp256k1.PrivateKey, recvPubkey *secp256k1.PublicKey) []byte {
-	// TODO: Make sure keys are not invalid or weak since the secp256k1 package does not.
-	// See documentation of secp256k1.PrivKeyFromBytes:
-	// ================================================================================
-	// | WARNING: This means passing a slice with more than 32 bytes is truncated and |
-	// | that truncated value is reduced modulo N.  Further, 0 is not a valid private |
-	// | key.  It is up to the caller to provide a value in the appropriate range of  |
-	// | [1, N-1].  Failure to do so will either result in an invalid private key or  |
-	// | potentially weak private keys that have bias that could be exploited.        |
-	// ================================================================================
-	// -- https://pkg.go.dev/github.com/decred/dcrd/dcrec/secp256k1/v4#PrivKeyFromBytes
-	shared := secp256k1.GenerateSharedSecret(sendPrivkey, recvPubkey)
-	return hkdf.Extract(sha256.New, shared, []byte("nip44-v2"))
+func GenerateConversationKey(sendPrivkey []byte, recvPubkey []byte) ([]byte, error) {
+	var (
+		N   = secp256k1.S256().N
+		sk  *secp256k1.PrivateKey
+		pk  *secp256k1.PublicKey
+		err error
+	)
+	// make sure that private key is on curve before using unsafe secp256k1.PrivKeyFromBytes
+	// see https://pkg.go.dev/github.com/decred/dcrd/dcrec/secp256k1/v4#PrivKeyFromBytes
+	skX := new(big.Int).SetBytes(sendPrivkey)
+	if skX.Cmp(big.NewInt(0)) == 0 || skX.Cmp(N) >= 0 {
+		return []byte{}, fmt.Errorf("invalid private key: x coordinate %s is not on the secp256k1 curve", hex.EncodeToString(sendPrivkey))
+	}
+	sk = secp256k1.PrivKeyFromBytes(sendPrivkey)
+	if pk, err = secp256k1.ParsePubKey(recvPubkey); err != nil {
+		return []byte{}, err
+	}
+	shared := secp256k1.GenerateSharedSecret(sk, pk)
+	return hkdf.Extract(sha256.New, shared, []byte("nip44-v2")), nil
 }
 
 func chacha20_(key []byte, nonce []byte, message []byte) ([]byte, error) {


### PR DESCRIPTION
As mentioned in #4, I updated `GenerateConversationKey` to accept bytes now:

> Therefore, I will need to update GenerateConversationKey to accept bytes (or hex strings) as the input so I can validate them before accepting them as keys.

This way, I can make sure that the private key is on the secp256k1 curve before `secp256k1.PrivKeyFromBytes` is used. This function is unsafe since it assumes that only private keys that are already known to be good are used.

Also did the following:

* removed disclaimer in Go README
* updated markdown table to remove "unsafe"
* update link to NIP-44 Go implementation on Github