### PR TITLE
doc: add clarity to audit status

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ NIP44 encrypted messages for [nostr](https://nostr.com).
 Spec copied from [github.com/nostr-protocol/nips](https://github.com/nostr-protocol/nips/blob/master/44.md).
 Audited on [2023.12](./audit-2023.12.pdf) by Cure53, Dr M. Heiderich, Dr. Mazaheri, Dr. Bleichenbacher.
 
-The implementations besides JS have not been audited: use at your own risk.
+Not all implementations have been audited. Only the TS/JS, Go, & Rust repos were included in the 2023.12 audit. Be sure to check the commits in scope of the audit & use at your own risk.
 
 | Language        | License       | Copied from                                |
 |-----------------|---------------|--------------------------------------------|


### PR DESCRIPTION
I was wary of the Rust library due to this message in the README but looking more closely at the audit PDF it looks like the December 2023 snapshot of https://github.com/mikedilger/nip44 was indeed included in the audit at least up until [this commit](https://github.com/mikedilger/nip44/commit/e6ab1bc4480fd53aa854814bbacacf200c51af14)

Probably better with this change to not scare people off as long as I'm not misunderstanding here